### PR TITLE
dependencies not loading for deluge due to openssl deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,61 @@
 FROM lsiobase/alpine.armhf
 MAINTAINER Gonzalo Peci <davyjones@linuxserver.io>, sparklyballs
 
-# environment variables
+# environment variables
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
-# install packages
+# set version label
+ARG BUILD_DATE
+ARG VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+
+# install runtime packages
 RUN \
  apk add --no-cache \
 	p7zip \
+	python \
 	unrar \
 	unzip && \
-
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/community \
-	py-service_identity && \
-
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	libressl2.4-libssl && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing \
-	deluge
+	deluge && \
 
-# add local files
+# install build packages
+ apk add --no-cache --virtual=build-dependencies \
+	g++ \
+	gcc \
+	libffi-dev \
+	py-pip \
+	python-dev && \
+
+ apk add --no-cache --virtual=build-dependencies2 \
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	libressl-dev && \
+
+# install pip packages
+ pip install --no-cache-dir -U \
+	crypto \
+	mako \
+	markupsafe \
+	pyopenssl \
+	service_identity \
+	six \
+	twisted \
+	zope.interface && \
+
+# cleanup
+ apk del --purge \
+	build-dependencies \
+	build-dependencies2 && \
+ rm -rf \
+	/root/.cache
+
+# add local files
 COPY root/ /
 
-# ports and volumes
+# ports and volumes
 EXPOSE 8112 58846 58946 58946/udp
 VOLUME /config /downloads

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [LinuxServer.io][linuxserverurl] team brings you another container release f
 * [Podcast][podcasturl] covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
 
 # lsioarmhf/deluge
-[![](https://images.microbadger.com/badges/image/lsioarmhf/deluge.svg)](http://microbadger.com/images/lsioarmhf/deluge "Get your own image badge on microbadger.com")[![Docker Pulls](https://img.shields.io/docker/pulls/lsioarmhf/deluge.svg)][hub][![Docker Stars](https://img.shields.io/docker/stars/lsioarmhf/deluge.svg)][hub][![Build Status](http://jenkins.linuxserver.io:8080/buildStatus/icon?job=Dockers/LinuxServer.io-armhf/lsioarmhf-deluge)](http://jenkins.linuxserver.io:8080/job/Dockers/job/LinuxServer.io-armhf/job/lsioarmhf-deluge/)
+[![](https://images.microbadger.com/badges/version/lsioarmhf/deluge.svg)](https://microbadger.com/images/lsioarmhf/deluge "Get your own version badge on microbadger.com")[![](https://images.microbadger.com/badges/image/lsioarmhf/deluge.svg)](http://microbadger.com/images/lsioarmhf/deluge "Get your own image badge on microbadger.com")[![Docker Pulls](https://img.shields.io/docker/pulls/lsioarmhf/deluge.svg)][hub][![Docker Stars](https://img.shields.io/docker/stars/lsioarmhf/deluge.svg)][hub][![Build Status](http://jenkins.linuxserver.io:8080/buildStatus/icon?job=Dockers/LinuxServer.io-armhf/lsioarmhf-deluge)](http://jenkins.linuxserver.io:8080/job/Dockers/job/LinuxServer.io-armhf/job/lsioarmhf-deluge/)
 [hub]: https://hub.docker.com/r/lsioarmhf/deluge/
 
 [deluge](http://deluge-torrent.org/) Deluge is a lightweight, Free Software, cross-platform BitTorrent client.
@@ -69,8 +69,18 @@ To change the password (recommended) log in to the web interface and go to Prefe
 
 * Monitor the logs of the container in realtime `docker logs -f deluge`.
 
+* container version number 
+
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' deluge`
+
+* image version number
+
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' lsioarmhf/deluge`
+
 ## Versions
 
++ **13.10.16:** Switch to libressl as openssl deprecated from alpine linux and deluge dependency
+no longer installs.
 + **30.09.16:** Fix umask.
 + **11.09.16:** Add layer badges to README.
 + **06.09.16:** Add badges to README.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- Having to switch from openssl to libressl due to alpine deprecation of openssl and deluge being called from the edge repository.
