### PR TITLE
switch to edge baseimage, image now builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM lsiobase/alpine.armhf
+FROM lsiobase/alpine.armhf:edge
 MAINTAINER Gonzalo Peci <davyjones@linuxserver.io>, sparklyballs
 
-# environment variables
+# environment variables
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
 # set version label
@@ -9,33 +9,30 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
-# install runtime packages
+# install runtime packages
 RUN \
  apk add --no-cache \
+	libressl2.4-libssl \
 	p7zip \
-	python \
 	unrar \
 	unzip && \
- apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/main \
-	libressl2.4-libssl && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing \
 	deluge && \
 
-# install build packages
+# install build packages
  apk add --no-cache --virtual=build-dependencies \
 	g++ \
 	gcc \
 	libffi-dev \
-	py-pip \
-	python-dev && \
-
- apk add --no-cache --virtual=build-dependencies2 \
-	--repository http://nl.alpinelinux.org/alpine/edge/main \
-	libressl-dev && \
+	libressl-dev \
+	py2-pip \
+	python2-dev && \
 
 # install pip packages
+ pip install --no-cache-dir -U \
+	incremental \
+	pip && \
  pip install --no-cache-dir -U \
 	crypto \
 	mako \
@@ -46,16 +43,15 @@ RUN \
 	twisted \
 	zope.interface && \
 
-# cleanup
+# cleanup
  apk del --purge \
-	build-dependencies \
-	build-dependencies2 && \
+	build-dependencies && \
  rm -rf \
 	/root/.cache
 
-# add local files
+# add local files
 COPY root/ /
 
-# ports and volumes
+# ports and volumes
 EXPOSE 8112 58846 58946 58946/udp
 VOLUME /config /downloads

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 # install runtime packages
 RUN \
  apk add --no-cache \
+	ca-certificates \
 	libressl2.4-libssl \
 	p7zip \
 	unrar \
@@ -19,6 +20,9 @@ RUN \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing \
 	deluge && \
+
+# update certificates
+ update-ca-certificates && \
 
 # install build packages
  apk add --no-cache --virtual=build-dependencies \

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To change the password (recommended) log in to the web interface and go to Prefe
 
 ## Versions
 
++ **17.11.16:** Rebase to edge baseimage.
 + **13.10.16:** Switch to libressl as openssl deprecated from alpine linux and deluge dependency
 no longer installs.
 + **30.09.16:** Fix umask.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ switch to edge baseimage
+ not sure about new warning in logs , investigating
+ warning `/usr/lib/python2.7/site-packages/deluge/_libtorrent.py:59: RuntimeWarning: to-Python converter for boost::shared_ptr<libtorrent::alert> already registered; second conversion method ignored.
  import libtorrent as lt`

