### PR TITLE
change repo for libressl2.6-libssl to edge main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN \
 	unrar \
 	unzip && \
  apk add --no-cache \
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	libressl2.6-libssl && \
+ apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing \
 	deluge && \
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To change the password (recommended) log in to the web interface and go to Prefe
 
 ## Versions
 
++ **20.11.17:** Change libressl2.6-libssl repo.
 + **01.07.17:** Add curl package.
 + **27.05.17:** Rebase to alpine 3.6.
 + **29.04.17:** Add variable for user defined umask.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

